### PR TITLE
Pump.fun launch updates

### DIFF
--- a/components/Faq.js
+++ b/components/Faq.js
@@ -12,12 +12,12 @@ const faqItems = [
   {
     question: "What is $ESSENCE?",
     answer:
-      "$ESSENCE is the core token of Sol Kingdoms, earned through gameplay and stored in the Royal City. It will be launched on pump.fun after the game is fully complete.",
+      "$ESSENCE is the core token of Sol Kingdoms, earned through gameplay and stored in the Royal City. It is launching on pump.fun with a fair public sale.",
   },
   {
     question: "When will the token launch?",
     answer:
-      "The $ESSENCE token will launch on pump.fun after the game development is complete and fully tested. We're focusing on delivering a polished gaming experience first.",
+      "The $ESSENCE token is going live on pump.fun as we finish polishing the game. Early supporters can join the sale while development continues.",
   },
   {
     question: "How can I play the game now?",

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -39,7 +39,7 @@ export default function Footer() {
             </li>
             <li>
               <a href="https://pump.fun" target="_blank" rel="noreferrer">
-                pump.fun (Coming Soon)
+                Buy on pump.fun
               </a>
             </li>
             <li>

--- a/components/Header.js
+++ b/components/Header.js
@@ -29,10 +29,19 @@ export default function HeroHeader() {
       <div className="absolute bottom-32 w-full z-10 flex flex-col items-center justify-center text-center transition-opacity duration-1000 px-4">
 
         <a
-          href="https://beta-play.solkingdoms.xyz"
+          href="https://pump.fun"
           target="_blank"
           rel="noopener noreferrer"
           className="uppercase font-semibold text-lg px-10 py-3 rounded-md bg-gradient-to-b from-[#f6e27a] to-[#d6a93f] text-[#2d1a00] border border-yellow-500 shadow-[0_5px_15px_rgba(255,223,100,0.3)] hover:brightness-110 hover:shadow-[0_8px_20px_rgba(255,223,100,0.5)] transition-all duration-300"
+        >
+          Buy on pump.fun
+        </a>
+
+        <a
+          href="https://beta-play.solkingdoms.xyz"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 uppercase font-semibold text-lg px-10 py-3 rounded-md bg-gradient-to-b from-[#f6e27a] to-[#d6a93f] text-[#2d1a00] border border-yellow-500 shadow-[0_5px_15px_rgba(255,223,100,0.3)] hover:brightness-110 hover:shadow-[0_8px_20px_rgba(255,223,100,0.5)] transition-all duration-300"
         >
           Play The Beta
         </a>

--- a/components/Intro.js
+++ b/components/Intro.js
@@ -17,7 +17,7 @@ export default function Intro() {
     </p>
     <p className="text-base md:text-lg text-gray-400">
     In a world cursed by endless cycles of rise and ruin, only the strongest kingdoms endure. Manage resources, forge alliances, and strike at the heart of your enemies.
-    Earn Essence through gameplay mastery. When the game launches fully, <strong className="text-yellow-400">$ESSENCE will be available on pump.fun</strong> as a reward for the most skilled players.
+    Earn Essence through gameplay mastery. <strong className="text-yellow-400">$ESSENCE launches on pump.fun</strong> to reward the most skilled players.
     </p>
     </div>
 

--- a/components/Roadmap.js
+++ b/components/Roadmap.js
@@ -35,7 +35,7 @@ const roadmapData = [
   {
     date: "2025-09-15",
     title: "Token Launch",
-    desc: "$ESSENCE launches on pump.fun after successful game launch",
+    desc: "$ESSENCE launches on pump.fun with fair distribution",
   },
   {
     date: "2025-10-01",

--- a/components/Tokenomics.js
+++ b/components/Tokenomics.js
@@ -32,7 +32,7 @@ export default function TokenomicsSection() {
             Players who master the game and accumulate Essence gain access to exclusive upgrades, economy boosts, governance decisions, and cross-season advantages. It represents power, legacy, and proven gaming excellence.
           </p>
           <p>
-            <strong>$ESSENCE will launch on pump.fun</strong> after the game development is complete, ensuring a <span className="text-yellow-400 font-semibold">fair and merit-based distribution</span> to skilled players.
+            <strong>$ESSENCE is launching on pump.fun</strong> to ensure a <span className="text-yellow-400 font-semibold">fair and merit-based distribution</span> to skilled players.
           </p>
           <p className="text-white font-medium italic">
             Master the game. Earn your Essence. Build your legacy.

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,12 +18,12 @@ export default function Home() {
     <>
       <Head>
         <title>Sol Kingdoms – Web3 strategy citybuild mmo</title>
-        <meta name="description" content="Build your kingdom, survive the storm, and earn Essence on Solana. Play the next-gen strategy game in cycles of conquest and glory." />
+        <meta name="description" content="Build your kingdom, survive the storm, and earn Essence on Solana. $ESSENCE launches on pump.fun for our community." />
         <meta name="keywords" content="Sol Kingdoms, blockchain game, play to earn, Solana, essence token, survival strategy, web3, crypto game, colonize, Solana game" />
         <meta name="author" content="Sol Kingdoms" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta property="og:title" content="Sol Kingdoms – Build. Survive. Earn." />
-        <meta property="og:description" content="Conquer the world in cycles. Earn $ESSENCE and keep your progress every season." />
+        <meta property="og:description" content="Conquer the world in cycles. Earn $ESSENCE and join our launch on pump.fun." />
         <meta property="og:image" content="/images/og-banner.jpg" />
         <meta property="og:url" content="https://www.solkingdoms.xyz" />
         <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
## Summary
- highlight the upcoming pump.fun release with a new button on the hero header
- update FAQ answers about the token launch
- tweak intro and tokenomics sections
- update roadmap and footer wording
- adjust meta description for pump.fun

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870022e1bf4832384c880032284814d